### PR TITLE
Bugfix/fix links and buttons

### DIFF
--- a/client/src/assets/scss/main.scss
+++ b/client/src/assets/scss/main.scss
@@ -70,11 +70,11 @@ a:hover {
 }
 
 .button__shadow {
-  border-radius: 0;
+  border-radius: 2px;
   background-color: $orange;
   color: black;
   font-weight: bolder;
-  box-shadow: -4px -4px black;
+  box-shadow: -3px -3px black;
   border: 2px solid black;
   margin: 15px;
   
@@ -91,12 +91,12 @@ a:hover {
 
 .button__shadow--blue {
   background-color: $blue;
-  color: white
+  color: white;
 }
 
 .section__modify-buttons {
-  margin: 3px;
-  @include xy-gutters($gutter-position: left right bottom);
+  margin: 5px 0;
+  @include xy-gutters($gutter-position: left bottom);
 }
 
 .button__delete {
@@ -221,7 +221,7 @@ a:hover {
 .list {
   border: $blue 1px solid;
   border-radius: $border-radius-px;
-  padding: 20px 20px 40px 20px;
+  padding: 20px 30px 40px 30px;
   background-color: white;
 }
 
@@ -229,6 +229,7 @@ a:hover {
   letter-spacing: .2em;
   text-decoration: underline 2px;
   text-underline-offset: 5px;
+  margin-bottom: 35px;
 }
 
 .menu {
@@ -262,16 +263,12 @@ a:hover {
 .quest-list-item {
   border-radius: $border-radius-px;
   border: $blue solid 2px;
-  padding: 20px;
-  margin: 15px 15px 0 15px;
+  padding: 15px;
   display: block;
   background-color: $light-orange;
   text-align: center;
-
-  a {
-    color: black;
-    font-weight: bold;
-  }
+  color: black;
+  font-weight: bold;
 }
 
 .quest-list-item:hover {
@@ -288,7 +285,7 @@ a:hover {
   box-shadow: inset 0 -6px 0 $green;
   padding: 0 0 2px 5px;
   background-color: transparent;
-  margin: 15px 15px 5px 15px;
+  margin: 15px 0 5px 0;
 
   p {
     margin: 0;
@@ -420,7 +417,7 @@ a:hover {
   box-shadow: inset 3.6em 0 0 0 $red;
   padding: 1px 2px 0 13px;
   background-color: transparent;
-  margin: 15px 15px 5px 15px;
+  margin: 15px 0 5px 0;
 
   p {
     margin: 0;

--- a/client/src/assets/scss/main.scss
+++ b/client/src/assets/scss/main.scss
@@ -131,6 +131,11 @@ a:hover {
   }
 }
 
+.back-icon {
+  font-size: 1em;
+  text-align: right;
+}
+
 .close-icon {
   float: right;
 }
@@ -181,7 +186,7 @@ a:hover {
 }
 
 .header--quest-title {
-  margin: 40px 20px 10px 20px;
+  margin: 30px 20px 10px 20px;
 }
 
 .landing__header {
@@ -477,7 +482,7 @@ a:hover {
 }
 
 .top-bar {
-  padding: 10px 20px;
+  padding: 10px 25px;
   width: 100%;
 }
 

--- a/client/src/assets/scss/main.scss
+++ b/client/src/assets/scss/main.scss
@@ -38,6 +38,7 @@ $font-header: 'Space Grotesk', sans-serif;
 $font-body: 'Montserrat', sans-serif;
 
 $border-radius-px: 4px;
+$button-border-radius-px: 2px;
 
 body {
   font-family: $font-body;
@@ -58,35 +59,28 @@ a:hover {
 }
 
 .button {
-  border-radius: 20px;
-  border: black solid 1px;
+  padding: 0.5rem 1rem;
+  border-radius: $button-border-radius-px;
+  border: 2px solid black;
   font-family: $font-header;
   font-weight: bold;
-  padding: 0.5rem 1rem;
 }
 
 .button:hover {
-  background-color: black;
+  background-color: $orange;
+  color: black;
+  box-shadow: none;
 }
 
 .button__shadow {
-  border-radius: 2px;
   background-color: $orange;
   color: black;
-  font-weight: bolder;
   box-shadow: -3px -3px black;
-  border: 2px solid black;
   margin: 15px;
   
   a {
     color: black;
   }
-}
-
-.button__shadow:hover {
-  background-color: $orange;
-  color: black;
-  box-shadow: none;
 }
 
 .button__shadow--blue {
@@ -234,14 +228,11 @@ a:hover {
 
 .menu {
   align-items: center;
-}
-
-.menu .button {
-  padding: 0.4rem 1rem 0.5rem 1rem;
-  font-family: $font-header;
-  font-weight: normal;
-  font-size: 16px;
-  border-radius: $border-radius-px;
+  
+  .button {
+    padding: 0.5rem 1rem;
+    font-size: 16px;
+  }
 }
 
 .menu-text__app-name {

--- a/client/src/components/UserSummary.js
+++ b/client/src/components/UserSummary.js
@@ -37,7 +37,7 @@ const UserSummary = (props) => {
   let newQuestToggle
   if (!showQuestForm) {
     newQuestToggle = <button type="button"
-      className="text-center button button__shadow button__shadow--blue"
+      className="button button__shadow button__shadow--blue"
       onClick={toggleQuestForm}>
         Add Quest
       </button>
@@ -81,7 +81,7 @@ const UserSummary = (props) => {
           </div>
           {dataVisualizationComponent}
         </div>
-        <div className="cell small-10 large-4 small-offset-1 large-offset-2">
+        <div className="cell small-10 large-4 small-offset-1 large-offset-2 text-center">
           <QuestList quests={quests} setQuests={setQuests} />
           {newQuestToggle}
         </div>

--- a/client/src/components/layout/Footer.js
+++ b/client/src/components/layout/Footer.js
@@ -7,12 +7,12 @@ const Footer = (props) => {
     <div className="footer">
       <ul className="menu simple align-center">
         <li>
-          <a href="https://www.linkedin.com/in/chelsea-elizabeth-smith/">
+          <a href="https://www.linkedin.com/in/chelsea-elizabeth-smith/" target="_blank">
             <FaLinkedin />
           </a>
         </li>
         <li>
-          <a href="https://github.com/chelscodes">
+          <a href="https://github.com/chelscodes" target="_blank">
             <FaGithub />
           </a>
         </li>

--- a/client/src/components/quests/QuestForm.js
+++ b/client/src/components/quests/QuestForm.js
@@ -74,7 +74,7 @@ const QuestForm = (props) => {
         />
         <button 
           type="button"
-          className="button button__shadow button__shadow--blue"
+          className="button__delete"
           onClick={clearForm}
         >Clear</button>
       </form>

--- a/client/src/components/quests/QuestShow.js
+++ b/client/src/components/quests/QuestShow.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react"
+import { Link } from "react-router-dom"
 
+import { TiArrowBack } from "react-icons/ti"
 import TaskArea from "../tasks/TaskArea"
 import RewardArea from "../rewards/RewardArea"
 
@@ -44,8 +46,17 @@ const QuestShow = (props) => {
   
   return (
     <div className="text-center">
-      <h2 className="header header--quest-title">{quest.name}</h2>
-      <p>current reward pts: <span className="bold--yellow">{currentPoints}</span></p>
+      <div className="grid-x">
+        <div className="cell medium-1 hide-for-small-only back-icon">
+          <Link to="/user-summary">
+            <TiArrowBack /> Back
+          </Link>
+        </div>
+        <div className="cell medium-10">
+          <h2 className="header header--quest-title">{quest.name}</h2>
+          <p>current reward pts: <span className="bold--yellow">{currentPoints}</span></p>
+        </div>
+      </div>
       <div className="grid-x">
         <p className="cell large-4 large-offset-4 quest__description">{quest.description}</p>
       </div>

--- a/client/src/components/quests/QuestTile.js
+++ b/client/src/components/quests/QuestTile.js
@@ -8,9 +8,11 @@ const QuestTile = (props) => {
 
   return (
     <>
-      <div className="quest-list-item">
-        <Link to={`/quests/${id}`} >{name}</Link>
-      </div>
+      <Link to={`/quests/${id}`} >
+        <div className="quest-list-item">
+          {name}
+        </div>
+      </Link>
       <div className="grid-x section__modify-buttons">
         <button className="cell button__delete" onClick={handleDeleteClick}>delete</button>
       </div>

--- a/client/src/components/rewards/RewardForm.js
+++ b/client/src/components/rewards/RewardForm.js
@@ -80,7 +80,7 @@ const RewardForm = (props) => {
         />
         <button 
           type="button"
-          className="button button__shadow button__shadow--blue"
+          className="button__delete"
           onClick={clearForm}
         >Clear</button>
       </form>

--- a/client/src/components/tasks/TaskForm.js
+++ b/client/src/components/tasks/TaskForm.js
@@ -81,7 +81,7 @@ const TaskForm = (props) => {
         />
         <button 
           type="button"
-          className="button button__shadow button__shadow--blue"
+          className="button__delete"
           onClick={clearForm}
         >Clear</button>
       </form>


### PR DESCRIPTION
### Footer Links

- updated LinkedIn and GitHub links to open in a new tab

### Quest Tile - Button

- fixed `QuestTile` so the whole area is clickable rather than just the text

### Quest Form Button

- centered the button for the `QuestForm` to match formatting elsewhere

### Back Button on Quest

- added a back button on the top of `QuestShow` so that it's clearer how to go back
- button disappears on small screen

### Styling

- updated button styling to be less complicated and more uniform
- adjusted top bar margin (moved with button edits)
- changed styling for the clear button to differentiate from submit button